### PR TITLE
Add the entry point to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,4 @@ FROM resin/armv7hf-debian:jessie
 
 ENV QEMU_EXECVE 1
 COPY . /usr/bin
+ENTRYPOINT ["qemu-arm-static", "/bin/bash"]


### PR DESCRIPTION
Able to launch a container just by `docker run -it <image>`
